### PR TITLE
Fix format of keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -28,4 +28,4 @@ Thing	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-THING_TOKEN	LITERAL1	PREPROCESSOR
+THING_TOKEN	LITERAL1		PREPROCESSOR


### PR DESCRIPTION
keywords.txt's third field is for links to the Arduino Language/Libraries reference pages. The fourth field is for `RSYNTAXTEXTAREA_TOKENTYPE`s such as `PREPROCESSOR`.

Each field is separated by a single true tab.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format